### PR TITLE
Fix update script

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,2 @@
+nordlayer-latest
+3.13.3

--- a/update_pkgbuild.py
+++ b/update_pkgbuild.py
@@ -56,14 +56,17 @@ if __name__ == '__main__':
     if (latest_version := get_latest_version()):
 
         print(f'Found latest version: {latest_version}')
-        print("Updating version and source in PKBUILD.")
+        print("Updating version and source in PKGBUILD.")
 
-        with open("PKGBUILD", "r+") as pkbuild_file:
-            pkbuild_file.write(
-                update_pkgbuild(pkbuild_file.read(), latest_version)
-            )
+        with open("PKGBUILD", "r+") as pkgbuild_file:
+            if (pkgbuild_content := pkgbuild_file.read()):
+                pkgbuild_file.seek(0)
+                pkgbuild_file.truncate(0)
+                pkgbuild_file.write(update_pkgbuild(pkgbuild_content, latest_version))
+            else:
+                print("PKGBUILD appears to be empty, or reading the file failed.")
 
-        print("Updating checksums in PKBUILD file, using updpkgsums from pacman-contrib package.")
+        print("Updating checksums in PKGBUILD file, using updpkgsums from pacman-contrib package.")
 
         if (updpkgsums := shutil.which("updpkgsums")):
             subprocess.run([updpkgsums], check=True)

--- a/update_pkgbuild.py
+++ b/update_pkgbuild.py
@@ -3,9 +3,8 @@
 import requests
 from bs4 import BeautifulSoup
 import re
-import hashlib
 import subprocess
-import os
+import shutil
 
 def get_latest_version():
     url = 'https://help.nordlayer.com/docs/linux'
@@ -38,82 +37,22 @@ def get_latest_version():
                 return match.group(1)
     return None
 
-def update_pkgbuild(version):
-    # Update the PKGBUILD file
-    with open('PKGBUILD', 'r') as f:
-        pkgbuild = f.read()
-
-    pkgbuild = re.sub(r'^pkgver=.*$', f'pkgver={version}', pkgbuild, flags=re.MULTILINE)
-    pkgbuild = re.sub(r'^pkgrel=.*$', 'pkgrel=1', pkgbuild, flags=re.MULTILINE)
-    pkgbuild = re.sub(
-        r'^source=\(".*"\)$',
-        f'source=("https://downloads.nordlayer.com/linux/latest/debian/pool/main/nordlayer_{version}_amd64.deb")',
-        pkgbuild,
-        flags=re.MULTILINE
-    )
-    pkgbuild = re.sub(r"^sha512sums=\('.*'\)$", "sha512sums=('SKIP')", pkgbuild, flags=re.MULTILINE)
-
-    with open('PKGBUILD', 'w') as f:
-        f.write(pkgbuild)
-
-    print('PKGBUILD updated with the latest version.')
-
-def download_deb(version):
-    # Download the .deb file
-    url = f"https://downloads.nordlayer.com/linux/latest/debian/pool/main/nordlayer_{version}_amd64.deb"
-    filename = f"nordlayer_{version}_amd64.deb"
-    headers = {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
-                      'AppleWebKit/537.36 (KHTML, like Gecko) ' +
-                      'Chrome/58.0.3029.110 Safari/537.36'
-    }
-    response = requests.get(url, headers=headers, stream=True)
-    response.raise_for_status()
-    with open(filename, 'wb') as f:
-        for chunk in response.iter_content(chunk_size=8192):
-            f.write(chunk)
-    print(f"Downloaded {filename}")
-    return filename
-
-def calculate_checksum(filename):
-    sha512 = hashlib.sha512()
-    with open(filename, 'rb') as f:
-        for chunk in iter(lambda: f.read(4096), b''):
-            sha512.update(chunk)
-    return sha512.hexdigest()
-
-def update_checksum(checksum):
-    # Update the checksum in the PKGBUILD
-    with open('PKGBUILD', 'r') as f:
-        pkgbuild = f.read()
-
-    pkgbuild = re.sub(r"^sha512sums=\('.*'\)$", f"sha512sums=('{checksum}')", pkgbuild, flags=re.MULTILINE)
-
-    with open('PKGBUILD', 'w') as f:
-        f.write(pkgbuild)
-
-    print('Checksum updated in PKGBUILD.')
-
-def update_srcinfo():
-    # Regenerate .SRCINFO
-    subprocess.run(['makepkg', '--printsrcinfo'], stdout=open('.SRCINFO', 'w'))
-    print('.SRCINFO updated.')
-
-def clean_up(filename):
-    if os.path.exists(filename):
-        os.remove(filename)
-        print(f"Removed temporary file {filename}")
 
 if __name__ == '__main__':
-    latest_version = get_latest_version()
-    if latest_version:
-        print(f'Latest version: {latest_version}')
-        update_pkgbuild(latest_version)
-        deb_filename = download_deb(latest_version)
-        checksum = calculate_checksum(deb_filename)
-        update_checksum(checksum)
-        update_srcinfo()
-        clean_up(deb_filename)
-        print('All updates completed successfully.')
+    print("Getting latest version from website...")
+    if (latest_version := get_latest_version()):
+        print(f'Found latest version: {latest_version}')
+        print("Updating PKBUILD file, using updpkgsums from pacman-contrib package.")
+        if (updpkgsums := shutil.which("updpkgsums")):
+            subprocess.run([updpkgsums], check=True)
+            print("Regenerating .SRCINFO file.")
+            if (makepkg := shutil.which("makepkg")):
+                with open(".SRCINFO", "w") as srcinfo_file:
+                    subprocess.run(['makepkg', '--printsrcinfo'], stdout=srcinfo_file, check=True)
+                print('All updates completed successfully; finished.')
+            else:
+                print("Cannot find makepkg. Maybe there is an issue with your PATH?")
+        else:
+            print("Cannot find updpkgsums. Install the pacman-contrib package and try again, or maybe there is an issue with your PATH?")
     else:
         print('Could not find the latest version. Please check the website or update the script.')

--- a/update_pkgbuild.py
+++ b/update_pkgbuild.py
@@ -37,18 +37,43 @@ def get_latest_version():
                 return match.group(1)
     return None
 
+def update_pkgbuild(pkgbuild, version):
+    # Update the PKGBUILD file content
+    pkgbuild = re.sub(r'^pkgver=.*$', f'pkgver={version}', pkgbuild, flags=re.MULTILINE)
+    pkgbuild = re.sub(r'^pkgrel=.*$', 'pkgrel=1', pkgbuild, flags=re.MULTILINE)
+    pkgbuild = re.sub(
+        r'^source=\(".*"\)$',
+        f'source=("https://downloads.nordlayer.com/linux/latest/debian/pool/main/nordlayer_{version}_amd64.deb")',
+        pkgbuild,
+        flags=re.MULTILINE
+    )
+    return pkgbuild
+
 
 if __name__ == '__main__':
-    print("Getting latest version from website...")
+    print("Getting latest version from website.")
+    
     if (latest_version := get_latest_version()):
+
         print(f'Found latest version: {latest_version}')
-        print("Updating PKBUILD file, using updpkgsums from pacman-contrib package.")
+        print("Updating version and source in PKBUILD.")
+
+        with open("PKGBUILD", "r+") as pkbuild_file:
+            pkbuild_file.write(
+                update_pkgbuild(pkbuild_file.read(), latest_version)
+            )
+
+        print("Updating checksums in PKBUILD file, using updpkgsums from pacman-contrib package.")
+
         if (updpkgsums := shutil.which("updpkgsums")):
             subprocess.run([updpkgsums], check=True)
+
             print("Regenerating .SRCINFO file.")
+
             if (makepkg := shutil.which("makepkg")):
                 with open(".SRCINFO", "w") as srcinfo_file:
                     subprocess.run(['makepkg', '--printsrcinfo'], stdout=srcinfo_file, check=True)
+
                 print('All updates completed successfully; finished.')
             else:
                 print("Cannot find makepkg. Maybe there is an issue with your PATH?")


### PR DESCRIPTION
Hello,
I tried to run the update script (because I wanted to update) but it did not work for me. So I made changes for myself, but I figured I'd share in case useful (feel free to reject this or whatever.)

Looks like the issue with the script is that the `update_checksum` function is looking to replace/modify `sha512sums` in `PKGBUILD` but the variable in there is `sha512sums_x86_64` so it fails to match and therefore checksum value doesn't get changed (the same thing is true for the `update_pkgbuild` function.) 

So in theory just changing those two lines would fix the script. However, when I started working on fixing the script, I ended up refactoring a lot of it.

NOTE: I did introduce a dependency on the [updpkgsums](https://man.archlinux.org/man/updpkgsums.8) script, from the [pacman-contrib](https://archlinux.org/packages/extra/x86_64/pacman-contrib/) package.

NOTE2: I also added `.python-version` file for those that use `pyenv` but also as a way to indicate the supported python version for the script.

I guess that's it.